### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ A Go package for quickly building tcp servers
 Usage
 ================
 
-###Install
+### Install
 
 ~~~
 go get github.com/gansidui/gotcp
 ~~~
 
 
-###Examples
+### Examples
 
 * [echo](https://github.com/gansidui/gotcp/tree/master/examples/echo)
 * [telnet](https://github.com/gansidui/gotcp/tree/master/examples/telnet)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
